### PR TITLE
Raise an error when template key cannot be found

### DIFF
--- a/chevron/renderer.py
+++ b/chevron/renderer.py
@@ -32,6 +32,9 @@ else:  # python 2
 # Helper functions
 #
 
+class TemplateError(BaseException):
+    pass
+
 def _html_escape(string):
     """HTML escape all of these " & < >"""
 
@@ -96,7 +99,7 @@ def _get_key(key, scopes, warn=False):
     # We couldn't find the key in any of the scopes
 
     if warn:
-        sys.stderr.write("Could not find key '%s'%s" % (key, linesep))
+        raise TemplateError("Missing a value for key '%s'" % (key, ))
 
     return ''
 


### PR DESCRIPTION
It's a bit dangerous that chevron doesn't raise an error by default when a template specifies keys that don't exist in the template data. This means that unit tests will generally not catch the error when a variable is mis-typed, or forgotten entirely in the template data.

@joshhansen Issuing a warning for these errors is quite helpful, thank you! But it's not sufficient for testing templates in a unit test. The library really needs to raise an error in order to be useful in unit tests.